### PR TITLE
add 180s timeout for pouchdb requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,19 +15,20 @@
     "angular": "^1.5.5"
   },
   "devDependencies": {
-    "angular-pouchdb": "^4.0.0",
-    "ng-smart-id": "fielded/ng-smart-id#4.0.3",
     "angular-mocks": "^1.5.5",
+    "angular-pouchdb": "^4.0.0",
     "babel-core": "^6.8.0",
     "babel-preset-es2015-rollup": "^1.1.1",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.22",
     "karma-jasmine": "^1.0.2",
     "karma-phantomjs-launcher": "^1.0.0",
+    "ng-smart-id": "fielded/ng-smart-id#4.0.3",
     "phantomjs-prebuilt": "^2.1.7",
     "rollup": "^0.26.3",
     "rollup-plugin-babel": "^2.4.0",
     "rollup-plugin-commonjs": "^2.2.1",
+    "rollup-plugin-json": "^2.0.2",
     "rollup-plugin-node-resolve": "^1.5.0",
     "rollup-plugin-uglify": "^1.0.0",
     "standard": "^7.1.1"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import babel from 'rollup-plugin-babel'
 import commonjs from 'rollup-plugin-commonjs'
 import nodeResolve from 'rollup-plugin-node-resolve'
+import json from 'rollup-plugin-json'
 
 export default {
   entry: 'src/index.js',
@@ -8,6 +9,9 @@ export default {
   external: ['angular'],
   format: 'iife',
   plugins: [
+    json({
+      exclude: ['node_modules/**']
+    }),
     babel({
       exclude: ['node_modules/**']
     }),

--- a/src/config.json
+++ b/src/config.json
@@ -1,0 +1,5 @@
+{
+  "replication": {
+    "timeout": 180000
+  }
+}

--- a/src/locations/locations.service.js
+++ b/src/locations/locations.service.js
@@ -1,3 +1,5 @@
+import { replication as replicationConfig } from '../config.json'
+
 const registerCallback = (replicationFrom, callback) => {
   replicationFrom.then(callback)
 }
@@ -8,7 +10,7 @@ class LocationsService {
 
     const pouchDBOptions = {
       ajax: {
-        timeout: 180000
+        timeout: replicationConfig.timeout
       }
     }
 

--- a/src/locations/locations.service.js
+++ b/src/locations/locations.service.js
@@ -6,6 +6,12 @@ class LocationsService {
   constructor ($injector, pouchDB, angularNavDataUtilsService) {
     let dataModuleRemoteDB
 
+    const pouchDBOptions = {
+      ajax: {
+        timeout: 180000
+      }
+    }
+
     try {
       dataModuleRemoteDB = $injector.get('dataModuleRemoteDB')
     } catch (e) {
@@ -15,7 +21,7 @@ class LocationsService {
     this.pouchDB = pouchDB
     this.angularNavDataUtilsService = angularNavDataUtilsService
 
-    this.remoteDB = this.pouchDB(dataModuleRemoteDB)
+    this.remoteDB = this.pouchDB(dataModuleRemoteDB, pouchDBOptions)
     this.replicationFrom
     this.localDB
     this.onReplicationCompleteCallbacks = {}

--- a/src/products/products.service.js
+++ b/src/products/products.service.js
@@ -6,6 +6,10 @@ class ProductsService {
   constructor ($injector, pouchDB, angularNavDataUtilsService) {
     let dataModuleRemoteDB
 
+    const pouchDBOptions = {
+      ajax: {timeout: 180000}
+    }
+
     try {
       dataModuleRemoteDB = $injector.get('dataModuleRemoteDB')
     } catch (e) {
@@ -15,7 +19,7 @@ class ProductsService {
     this.pouchDB = pouchDB
     this.angularNavDataUtilsService = angularNavDataUtilsService
 
-    this.remoteDB = this.pouchDB(dataModuleRemoteDB)
+    this.remoteDB = this.pouchDB(dataModuleRemoteDB, pouchDBOptions)
     this.replicationFrom
     this.localDB
     this.onReplicationCompleteCallbacks = {}

--- a/src/products/products.service.js
+++ b/src/products/products.service.js
@@ -1,3 +1,5 @@
+import { replication as replicationConfig } from '../config.json'
+
 const registerCallback = (replicationFrom, callback) => {
   replicationFrom.then(callback)
 }
@@ -7,7 +9,9 @@ class ProductsService {
     let dataModuleRemoteDB
 
     const pouchDBOptions = {
-      ajax: {timeout: 180000}
+      ajax: {
+        timeout: replicationConfig.timeout
+      }
     }
 
     try {


### PR DESCRIPTION
Fixes a condition in which individual requests for large documents may consistently time out on poor connections, rendering a dashboard unuseable as integrated data can't be retrieved.

Note timeout config is not abstracted and should be for consistency and ease of modification.
Refs https://github.com/fielded/nav-integrated-state-dashboard/issues/786 and should be used in conjunction with https://github.com/fielded/angular-nav-data/pull/37 

![screen shot 2016-09-18 at 3 26 36 pm](https://cloud.githubusercontent.com/assets/58843/18616009/59bde142-7db4-11e6-88ca-a618064f9019.png)
