### PR TITLE
[RFC] perf: try all/bulkDocs with new_edits false

### DIFF
--- a/src/products/products.service.js
+++ b/src/products/products.service.js
@@ -1,3 +1,5 @@
+import { bulkForceInsert } from '../utils'
+
 const registerCallback = (replicationFrom, callback) => {
   replicationFrom.then(callback)
 }
@@ -22,17 +24,8 @@ class ProductsService {
   }
 
   startReplication (zone, state) {
-    var options = {
-      filter: 'products/all'
-    }
-
     this.localDB = this.pouchDB('navIntProductsDB')
-    this.replicationFrom = this.localDB.replicate.from(this.remoteDB, options)
-
-    Object.keys(this.onReplicationCompleteCallbacks)
-      .forEach((id) => registerCallback(this.replicationFrom, this.onReplicationCompleteCallbacks[id]))
-
-    return this.replicationFrom
+    return bulkForceInsert(this.localDB, this.remoteDB, 'product:')
   }
 
   callOnReplicationComplete (id, callback) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,12 @@
+exports.bulkForceInsert = (localDB, remoteDB, id) => {
+  const opts = {
+    include_docs: true,
+    startkey: id,
+    endkey: `${id}\uffff`
+  }
+  return remoteDB.allDocs(opts)
+    .then(res => res.rows.map(row => row.doc))
+    .then(docs => localDB.bulkDocs(docs, {
+      new_edits: false
+    }))
+}


### PR DESCRIPTION
**Note** not intended to be merged (just yet); just a proof of concept.

Since we never modify locations or products in the client, mimic a one-way replication from the server using allDocs and bulkDocs. Note passing `new_edits: false` causes the docs to be forcibly inserted; all previous (local) revs are lost. This is fine in these cases as we always treat the server's location and product docs the canonical/winning docs.

On cold starts, this approach works well as it reduces the number of requests from `n + 2` location docs (`n` lgas + state doc + configuration doc) + `m` products + replication overhead (checkpoints etc.) to 3 (1 for locations, 1 for configuration, 1 for products).

On warm starts, this is less beneficial as the entire documents are re-downloaded (~15KB) rather than only their diffs as replication would do. Still the number of requests are reduced, which is what we want (latency is our biggest concern on our target connection profile).

Connects fielded/nav-integrated-state-dashboard#786.
