### PR TITLE
perf: skip remote PouchDB checks

### DIFF
--- a/src/locations/locations.service.js
+++ b/src/locations/locations.service.js
@@ -11,7 +11,8 @@ class LocationsService {
     const pouchDBOptions = {
       ajax: {
         timeout: replicationConfig.timeout
-      }
+      },
+      skip_setup: true
     }
 
     try {

--- a/src/products/products.service.js
+++ b/src/products/products.service.js
@@ -11,7 +11,8 @@ class ProductsService {
     const pouchDBOptions = {
       ajax: {
         timeout: replicationConfig.timeout
-      }
+      },
+      skip_setup: true
     }
 
     try {


### PR DESCRIPTION
> skip_setup: Initially PouchDB checks if the database exists, and tries to
> create it, if it does not exist yet. Set this to true to skip this setup.

This saves an extra request per remote DB instance.

We programmatically bootstrap the databases; if they do not exist, we've got
bigger issues. If for some reason the DB is missing, the attempt to create it
will fail anyway as our users aren't CouchDB admin users.

Connects https://github.com/fielded/nav-integrated-state-dashboard/issues/786.
